### PR TITLE
Release v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runicorn",
-  "version": "0.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runicorn",
-      "version": "0.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@types/leaflet": "^1.9.21",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runicorn",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 🚀 Release v1.0.1

Version bump from 0.0.0 to 1.0.1

This updates the package.json version for proper production deployment tracking.

### Changes
- Updated version to 1.0.1
- Created git tag v1.0.1

### Deployment
Discord will now show: **"Runicorn v1.0.1 deployed to production"** 🎉