### PR TITLE
Add Imprint link to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,12 +34,23 @@ export function Header({ onLogoClick }: HeaderProps) {
             </div>
           </button>
 
-          {/* Tagline */}
-          <div className="hidden md:flex items-center gap-4">
+          {/* Tagline & Imprint */}
+          <div className="flex items-center gap-4">
+            <div className="hidden md:flex items-center gap-4">
+              <Separator orientation="vertical" className="h-6" />
+              <p className="text-sm text-muted-foreground font-medium">
+                GPS art made simple
+              </p>
+            </div>
             <Separator orientation="vertical" className="h-6" />
-            <p className="text-sm text-muted-foreground font-medium">
-              GPS art made simple
-            </p>
+            <a
+              href="https://rnltlabs.de/imprint.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground font-medium hover:text-foreground transition-colors"
+            >
+              Imprint
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Add legally required Imprint link to header

## Changes
- Added Imprint link to top-right corner of header
- Desktop: Shows "GPS art made simple | Imprint"
- Mobile: Shows only "Imprint" (tagline hidden to save space)
- Links to https://rnltlabs.de/imprint.html
- Opens in new tab with proper security attributes

## Legal Requirement
Imprint (Impressum) is legally required for German websites.

## Checklist
- [x] Build passes
- [x] ESLint passes
- [x] Link opens in new tab
- [x] Responsive on mobile